### PR TITLE
Identify workspaces by number not name

### DIFF
--- a/toggle_workspace.sh
+++ b/toggle_workspace.sh
@@ -6,7 +6,7 @@ TMP_FILE_LOCATION_FOCUSED=/tmp/i3_focused_tmp
 get_i3_workspace_id() {
     field=$1
     i3-msg -t get_workspaces \
-  | jq '.[] | select(.'"$field"'==true).name' \
+  | jq '.[] | select(.'"$field"'==true).num' \
   | cut -d"\"" -f2
 }
 save_visible_workspaces() {
@@ -22,11 +22,11 @@ then
         intermediate_workspace=$(grep -v "$currently_visible_workspaces" $TMP_FILE_LOCATION_VISIBLE)
         if [[ "$intermediate_workspace" != $(cat $TMP_FILE_LOCATION_FOCUSED) ]]
         then
-                i3-msg workspace $intermediate_workspace
+                i3-msg workspace number $intermediate_workspace
         fi
-        i3-msg workspace "$(cat $TMP_FILE_LOCATION_FOCUSED)"
+        i3-msg workspace number "$(cat $TMP_FILE_LOCATION_FOCUSED)"
 else
         save_visible_workspaces
         save_active_workspace
-        i3-msg workspace $workspace_to_toggle
+        i3-msg workspace number $workspace_to_toggle
 fi


### PR DESCRIPTION
Allows more flexibility for working with a variety of named workspaces.